### PR TITLE
MeterianBot has fixed some issues in your codebase

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-requests = "==2.19.0"
+requests = "2.25.0"
 eo-lookup-revo = ">1.0.0"
 
 


### PR DESCRIPTION
Hey! We’ve found issues with one of the libraries you are using in your projectundefined.

The security score of your project is **100**, the stability score **100** and the licensing score **0**.
You can have a more detailed look at the report [here](https://qa.meterian.com/projects/?pid=339c70f4-03c1-4314-99f0-d17dbc4e5329&branch=master&mode=eli).

## Fixes
- We’ve updated **urllib3** **1.23** to **1.26.2** minor release, because of **[CVE-2020-26137](https://nvd.nist.gov/vuln/details/CVE-2020-26137)**.

&nbsp;&nbsp;&nbsp;&nbsp;Threat severity: **MEDIUM** &nbsp;&nbsp;&nbsp;&nbsp; CVSS score: **6.5**

>urllib3 before 1.25.9 allows CRLF injection if the attacker controls the HTTP request method, as demonstrated by inserting CR and LF control characters in the first argument of putrequest(). NOTE: this is similar to CVE-2020-26116.

---

- We’ve updated **requests** **2.19.0** to **2.25.0** minor release, because of **[CVE-2018-18074](https://nvd.nist.gov/vuln/details/CVE-2018-18074)**.

&nbsp;&nbsp;&nbsp;&nbsp;Threat severity: **HIGH** &nbsp;&nbsp;&nbsp;&nbsp; CVSS score: **9.8**

>The Requests package before 2.20.0 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.

---

## Issues
- **idna** **2.7** is outdated.

&nbsp;&nbsp;&nbsp;&nbsp;idna 2.10 minor release is the latest available version.

---

## Licenses
- 2 libraries declare a license which violates the company policies.

Have a look at the [report](https://qa.meterian.com/projects/?pid=339c70f4-03c1-4314-99f0-d17dbc4e5329&branch=master&mode=eli) for more details and find out [how a licenses can impact your business](https://blog.meterian.com/2019/05/22/how-the-wrong-license-can-harm-your-business/).